### PR TITLE
Update setup_model workflow to use sfincs region.geojson, fix fiat_build region reading

### DIFF
--- a/hydroflows/methods/fiat/fiat_build.py
+++ b/hydroflows/methods/fiat/fiat_build.py
@@ -54,6 +54,9 @@ class FIATBuild(Method):
         opt = configread(self.params.config)
         # Add additional information
         region_gdf = gpd.read_file(self.input.region.as_posix()).to_crs(4326)
+        # Select only geometry in case gdf contains more columns
+        # Hydromt-fiat selects first column for geometry when fetching OSM
+        region_gdf = region_gdf[['geometry']]
         opt.update(
             {"setup_region": {
                 "region": {"geom": region_gdf}

--- a/hydroflows/templates/workflow/setup_models.smk
+++ b/hydroflows/templates/workflow/setup_models.smk
@@ -24,7 +24,7 @@ rule setup_sfincs:
     output:
         sfincs_inp = f"models/sfincs/{region_name}/sfincs.inp",
         # This output is not defined in the method (it is not needed as an cli arguments), but is required to construct the desired DAG
-        sfincs_src_points = f"models/sfincs/{region_name}/gis/src.geojson"
+        sfincs_region = f"models/sfincs/{region_name}/gis/region.geojson"
 
     shell:
         """
@@ -40,7 +40,7 @@ rule setup_sfincs:
 
 rule setup_fiat:
     input:
-        region = region_file
+        region = rules.setup_sfincs.output.sfincs_region
 
     params:
         config = "workflow/hydromt_config/fiat_build.yaml",
@@ -63,7 +63,7 @@ rule setup_fiat:
 
 rule setup_wflow:
     input:
-        sfincs_src_points = f"models/sfincs/{region_name}/gis/src.geojson"
+        sfincs_region = rules.setup_sfincs.output.sfincs_region
 
     params:
         config = "workflow/hydromt_config/wflow_build.yaml",
@@ -76,7 +76,7 @@ rule setup_wflow:
         """
         hydroflows run \
         wflow_build \
-        -i sfincs_src_points={input.sfincs_src_points} \
+        -i sfincs_region={input.sfincs_region} \
         -o wflow_toml={output.wflow_toml} \
         -p config={params.config} \
         -p data_libs="{params.data_libs}"


### PR DESCRIPTION
## Issue addressed
Fixes #75 

## Explanation
wflow, fiat setup steps now use sfincs region.geojson to build models. Fix fiat_build method to always select geometry column when building model region

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `master`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
