### PR TITLE
create polygons

### DIFF
--- a/cases/Rio/scripts/preprocess_exposure.py
+++ b/cases/Rio/scripts/preprocess_exposure.py
@@ -89,6 +89,8 @@ social_class = pd.read_csv(social_class_path)
 # %% Create 2D building footprints
 # Apply the conversion to each geometry in the GeoDataFrame
 buildings_gdf["geometry"] = buildings_gdf["geometry"].apply(convert_to_2d)
+buildings_gdf = buildings_gdf.dissolve(by="COD_LOTE")
+buildings_gdf = buildings_gdf.explode()
 
 # %% link buildings entrances to footprints based on cod_lote
 # NOTE There are duplicates in the cod_lote so merge might create weird duplicates, prefer spatialjoint


### PR DESCRIPTION
## Issue addressed
The building footprints had overlapping features which would calculate a building multiple times and then overestimate the damages. Now the buildings with the same Lote are dissolved into one building and multipolygons are exploded into single polygons. 

Fixes #<issue number>

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `master`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
