### PR TITLE
make compatible with externally derived gridded forcing files

### DIFF
--- a/hydroflows/methods/sfincs/sfincs_update_forcing.py
+++ b/hydroflows/methods/sfincs/sfincs_update_forcing.py
@@ -103,7 +103,7 @@ class SfincsUpdateForcing(Method):
         if self.params.copy_model and not self.params.output_dir:
             raise ValueError("Unknown dest. folder for copy operation.")
 
-        sfincs_out_inp = self.params.output_dir / "sfincs.inp"
+        sfincs_out_inp = self.params.output_dir / self.params.event_name / "sfincs.inp"
         if not self.params.copy_model and not self.params.output_dir.is_relative_to(
             self.input.sfincs_inp.parent
         ):

--- a/hydroflows/methods/sfincs/sfincs_utils.py
+++ b/hydroflows/methods/sfincs/sfincs_utils.py
@@ -104,8 +104,16 @@ def parse_event_sfincs(
                 config.update({"disfile": "sfincs.dis", "srcfile": "sfincs.src"})
 
             case "rainfall":
-                sf.setup_precip_forcing(timeseries=forcing.data)
-                config.update({"precipfile": "sfincs.precip"})
+                if forcing.is_gridded:
+                    # use gridded precipitation forcing
+                    sf.setup_precip_forcing_from_grid(
+                        precip=forcing.path, aggregate=False
+                    )
+                    config.update({"netamprfile": "sfincs.netampr"})
+                else:
+                    # use time series precipitation forcing
+                    sf.setup_precip_forcing(timeseries=forcing.data)
+                    config.update({"precipfile": "sfincs.precip"})
 
     # change root and update config
     sf.set_root(out_root, mode="w+")


### PR DESCRIPTION
## Issue addressed
Hydroflows, when provided with a 2-d forcing grid would fail at the detection of an nc file. 

## Explanation
In this branch we allow for the supply of events that are 2d, e.g. Wflow effective precipitation forcings. The filetype is allowed in `_read_netcdf`, update to use `_setup_precip_forcing_from_grid` method `if forcing.is_gridded`, change the expected output to a 
`sfincs.netampr`. 

## Example use
Since we are skipping the wildcard creation that occurs with e.g. `rainfall.GetERA5Rainfall`, then we must introduce our wildcards at the initialisation of the `Workflow`:

```
# Define the return periods for wildcards
rps = [1, 2, 5, 10, 25, 50, 100]
event_names = [f"net_precip_{rp:03d}" for rp in rps]

# Create workflow with wildcards
w = Workflow(
    name=name, 
    config=config, 
    root=case_root,
    wildcards={"event": event_names}  # Add wildcards for events
)

... sfincs_build is unchanged ...
... skip rainfall and event wildcard creation ...

# Update the sfincs model with pluviual events using wildcards
sfincs_update = sfincs.SfincsUpdateForcing(
    sfincs_inp=sfincs_build.output.sfincs_inp,
    event_yaml=r"C:\git\kumasi\wflow\run_rps\net_precip\{event}.yml",  # Use wildcard
    output_dir=sfincs_build.output.sfincs_inp.parent/"simulations",
    event_name="{event}"  # Use wildcard for event name
)
w.create_rule(sfincs_update, rule_id="sfincs_update")
```

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `master`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
A Wflow effective precipitation method that performs the $P_{effective}=P - I - E_{actual} - \DeltaS$ would be a nice generalisable infiltration step.  
